### PR TITLE
docs: fix broken link to shared-plugins-during-build section (#700)

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -345,6 +345,10 @@ export default defineConfig({
               text: 'Migration von v4',
               link: '/guide/migration',
             },
+            {
+              text: 'Grundlegende Änderungen',
+              link: '/changes'
+            }
           ],
         },
         {
@@ -431,6 +435,45 @@ export default defineConfig({
               link: '/config/worker-options',
             },
           ],
+        },
+      ],
+      '/changes/': [
+        {
+          text: 'Grundlegende Änderungen',
+          link: '/changes/',
+        },
+        {
+          text: 'Aktuelles',
+          items: [],
+        },
+        {
+          text: 'Zukünftiges',
+          items: [
+            {
+              text: 'this.environment in Hooks',
+              link: '/changes/this-environment-in-hooks',
+            },
+            {
+              text: 'HMR hotUpdate Plugin Hook',
+              link: '/changes/hotupdate-hook',
+            },
+            {
+              text: 'Umstellung auf umgebungsbezogene APIs',
+              link: '/changes/per-environment-apis',
+            },
+            {
+              text: 'SSR verwendet die ModuleRunner API',
+              link: '/changes/ssr-using-modulerunner',
+            },
+            {
+              text: 'Gemeinsam genutzte Plugins während der Erstellung',
+              link: '/changes/shared-plugins-during-build',
+            },
+          ],
+        },
+        {
+          text: 'Vergangenes',
+          items: [],
         },
       ],
     },

--- a/docs/changes/hotupdate-hook.md
+++ b/docs/changes/hotupdate-hook.md
@@ -1,0 +1,124 @@
+# HMR `hotUpdate` Plugin Hook
+
+::: tip Feedback
+Geben Sie uns Rückmeldungen in der ["Environment API Feedback"-Diskussion](https://github.com/vitejs/vite/discussions/16358)
+:::
+
+Wir planen, den Plugin-Hook `handleHotUpdate` zugunsten des Hooks `hotUpdate` zu verwerfen, um Environment API-kompatibel zu sein und zusätzliche Überwachungsereignisse mit `create` und `delete` zu verarbeiten.
+
+Betroffener Bereich: `Vite Plugin-Authoren`
+
+
+
+::: warning Future Deprecation
+`hotUpdate` wurde zum ersten Mal in `v6.0` eingeführt. Die Veraltung von `handleHotUpdate` ist für eine zukünftige Hauptversion geplant. Wir empfehlen, vorerst noch nicht von `handleHotUpdate` abzuweichen. Wenn Sie herumexperimentieren möchten, können Sie gerne die `future.removePluginHookHandleHotUpdate` in Ihrer Vite-Konfiguration auf `"warn"` setzen und uns Feedback geben.
+:::
+
+## Motivation
+
+Die [`handleHotUpdate`-Hook](/guide/api-plugin.md#handlehotupdate) erlaubt eine benutzerdefinierte Behandlung von HMR Updates. Eine Liste der zu aktualisierenden Module wird im `HmrContext` angegeben.
+
+```ts
+interface HmrContext {
+  file: string
+  timestamp: number
+  modules: Array<ModuleNode>
+  read: () => string | Promise<string>
+  server: ViteDevServer
+}
+```
+
+Dieser Hook wird einmal für alle Umgebungen aufgerufen, und die übergebenen Module enthalten ausschließlich gemischte Informationen aus der Client- und der SSR-Umgebung. Sobald Frameworks zu benutzerdefinierten Umgebungen wechseln, wird für jede von ihnen eine neue Hook benötigt.
+
+Die neue `hotUpdate`-Hook funktioniert gleichartig wie `handleHotUpdate`, aber sie wird für jede Umgebung aufgerufen und erhält eine neue `HotUpdateOptions`-Instanz:
+
+```ts
+interface HotUpdateOptions {
+  type: 'create' | 'update' | 'delete'
+  file: string
+  timestamp: number
+  modules: Array<EnvironmentModuleNode>
+  read: () => string | Promise<string>
+  server: ViteDevServer
+}
+```
+
+Auf die aktuelle Entwicklungsumgebung kann, wie in anderen Plugin-Hooks, mit `this.environment` zugegriffen werden. Die `modules`-Liste wird von nun an nur noch Modulknoten aus der aktuellen Umgebung enthalten. Jedes Umgebungsupdate kann unterschiedliche Strategien zur Aktualisierung festlegen.
+
+Diese Hook wird nun auch für zusätzliche "watch"-Events aufgerufen und nicht nur für `'update'`. Verwenden Sie `type`, um zwischen ihnen zu unterscheiden.
+
+## Migrationsleitfaden
+
+Filtern und Einschränken der Liste der betroffenen Module, damit HMR präziser ist.
+
+```js
+handleHotUpdate({ modules }) {
+  return modules.filter(condition)
+}
+
+// Migration zu:
+
+hotUpdate({ modules }) {
+  return modules.filter(condition)
+}
+```
+
+Zurückgeben eines leeren Arrays, damit ein komplettes Neuladen stattfindet:
+
+```js
+handleHotUpdate({ server, modules, timestamp }) {
+  // Module manuell ungültig machen
+  const invalidatedModules = new Set()
+  for (const mod of modules) {
+    server.moduleGraph.invalidateModule(
+      mod,
+      invalidatedModules,
+      timestamp,
+      true
+    )
+  }
+  server.ws.send({ type: 'full-reload' })
+  return []
+}
+
+// Migration zu:
+
+hotUpdate({ modules, timestamp }) {
+  // Invalidate modules manually
+  const invalidatedModules = new Set()
+  for (const mod of modules) {
+    this.environment.moduleGraph.invalidateModule(
+      mod,
+      invalidatedModules,
+      timestamp,
+      true
+    )
+  }
+  this.environment.hot.send({ type: 'full-reload' })
+  return []
+}
+```
+
+Zurückgeben eines leeren Arrays und durchführen einer kompletten, benutzerdefinierten HMR-Behandlung durch das Versenden von benutzerdefinierten Events zum Client:
+
+```js
+handleHotUpdate({ server }) {
+  server.ws.send({
+    type: 'custom',
+    event: 'special-update',
+    data: {}
+  })
+  return []
+}
+
+// Migration zu...
+
+hotUpdate() {
+  this.environment.hot.send({
+    type: 'custom',
+    event: 'special-update',
+    data: {}
+  })
+  return []
+}
+```

--- a/docs/changes/index.md
+++ b/docs/changes/index.md
@@ -1,0 +1,26 @@
+# Grundlegende Änderungen
+
+Eine Liste der wesentlichen Änderungen in Vite, einschließlich API-Veraltungen, Entfernungen und Änderungen. Der Großteils der unten genannten Änderungen kann durch das Angeben der [`future`-Option](/config/shared-options.html#future) in der Vite-Konfiugration verwendet werden.
+
+## Geplant
+
+Die Änderungen sind für die nächste Hauptversion von Vite geplant. Die Verwendungswarnungen und Hinweise zur Abkündigung werden Ihnen, soweit möglich, als Orientierung dienen. Wir wenden uns auch an Framework- und Plugin-Autoren sowie an Nutzer, um diese Änderungen umzusetzen.
+
+- [`this.environment` in Hooks](/changes/this-environment-in-hooks)
+- [HMR `hotUpdate` Plugin Hook](/changes/hotupdate-hook)
+- [SSR verwendet die `ModuleRunner` API](/changes/ssr-using-modulerunner)
+
+## In Prüfung
+
+Diese Änderungen werden derzeit noch geprüft und sind oft experimentelle APIs, die zukünftige Nutzungsmustern verbessern sollen. Schauen Sie bitte in die [Vite GitHub Diskussionen mit dem "Experimental"-Label](https://github.com/vitejs/vite/discussions/categories/feedback?discussions_q=label%3Aexperimental+category%3AFeedback), da nicht alle Änderungen hier gelistet werden.
+
+Wir empfehlen es noch nicht, zu diesen APIs zu wechseln. Sie sind nur in Vite enthalten, um Rückmeldungen zu sammeln. Schauen Sie sich gern diese Vorschläge an und teilen Sie uns in den jeweiligen GitHub-Diskussionen mit, wie sie sich für Ihren Anwendungsfall eignen.
+
+- [Umstellung auf umgebungsbezogene APIs](/changes/per-environment-apis)
+- [Gemeinsam genutzte Plugins während der Erstellung](/changes/shared-plugins-during-build)
+
+## Vergangen
+
+Die unten gelisteten Änderungen wurden in der Vergangenheit implementiert oder zurückgesetzt. Für die aktuelle Hauptversion sind sie nicht länger relevant.
+
+- _Noch keine vergangenen Änderungen_

--- a/docs/changes/per-environment-apis.md
+++ b/docs/changes/per-environment-apis.md
@@ -1,0 +1,40 @@
+# Umstellung auf umgebungsbezogene APIs
+
+::: tip Feedback
+Geben Sie uns Rückmeldungen in der ["Environment API Feedback"-Diskussion](https://github.com/vitejs/vite/discussions/16358)
+:::
+
+Mehrere APIs von `ViteDevServer` bezogen auf den Modulgraph und Modultransformationen wurden in die `DevEnvironment`-Instanzen verschoben.
+
+Betroffener Bereich: `Vite Plugin-Authoren`
+
+::: warning Zukünftige Veraltungen
+Die `Environment`-Instanz wurde in `v6.0` eingeführt. Die Veraltung von `server.moduleGraph` und anderen Methoden, die sich jetzt in Umgebungen befinden, sind für eine zukünftige Hauptversion geplant. Wir empfehlen, vorerst bei den Server-Methoden zu bleiben. Um die Nutzung in Ihren Projekten zu identifizieren, setzen Sie diese Optionen in Ihrer Vite-Konfiguration.
+
+```ts
+future: {
+  removeServerModuleGraph: 'warn',
+  removeServerReloadModule: 'warn',
+  removeServerPluginContainer: 'warn',
+  removeServerHot: 'warn',
+  removeServerTransformRequest: 'warn',
+  removeServerWarmupRequest: 'warn',
+}
+```
+
+:::
+
+## Motivation
+
+In Vite v5 und früheren Versionen hatte ein einzelner Vite-Entwicklungsserver immer zwei Umgebungen (`client` und `ssr`). Die Option `server.moduleGraph` enthielt gemischte Module aus beiden Umgebungen. Die Knoten wurden über die Listen `clientImportedModules` und `ssrImportedModules` verbunden (für jede Umgebung wurde jedoch eine einzelne Liste `importers` verwaltet). Ein transformiertes Modul wurde durch eine `id` und einen `ssr`-booleschen Wert dargestellt. Dieser boolesche Wert musste an APIs übergeben werden, zum Beispiel `server.moduleGraph.getModuleByUrl(url, ssr)` und `server.transformRequest(url, { ssr })`.
+
+In Vite v6 ist es nun möglich, eine beliebige Anzahl von benutzerdefinierten Umgebungen (`client`, `ssr`, `edge`, etc.) zu erstellen. Ein einzelner boolescher Wert `ssr` reicht nicht mehr aus. Anstatt die APIs in die Form `server.transformRequest(url, { environment })` zu ändern, haben wir diese Methoden in die Umgebungsinstanz verschoben, sodass sie ohne einen Vite-Entwicklungsserver aufgerufen werden können.
+
+## Migrationsleitfaden
+
+- `server.moduleGraph` -> [`environment.moduleGraph`](/guide/api-environment-instances#separate-module-graphs)
+- `server.reloadModule(module)` -> `environment.reloadModule(module)`
+- `server.pluginContainer` -> `environment.pluginContainer`
+- `server.transformRequest(url, ssr)` -> `environment.transformRequest(url)`
+- `server.warmupRequest(url, ssr)` -> `environment.warmupRequest(url)`
+- `server.hot` -> `server.client.environment.hot`

--- a/docs/changes/shared-plugins-during-build.md
+++ b/docs/changes/shared-plugins-during-build.md
@@ -1,0 +1,83 @@
+# Gemeinsam genutzte Plugins während der Erstellung
+
+::: tip Feedback
+Geben Sie uns Rückmeldungen in der ["Environment API Feedback"-Diskussion](https://github.com/vitejs/vite/discussions/16358)
+:::
+
+Siehe [Gemeinsam genutzte Plugins während der Erstellung](/guide/api-environment-plugins.md#shared-plugins-during-build).
+
+Betroffener Bereich: `Vite Plugin-Authoren`
+
+::: warning Zukünftige Standardanpassungen
+`builder.sharedConfigBuild` wurde eingeführt in `v6.0`. Sie können den Wert auf `true` setzen, um zu prüfen wie Ihre Plugins mit einer gemeinsamen Konfiguration funktionieren. Wir suchen nach 
+
+ Wir suchen Feedback zur Änderung der Standardeinstellung in einer zukünftigen Hauptversion, sobald das Plugin-Ökosystem bereit ist.
+:::
+
+## Motivation
+
+Entwicklungs- und Build-Plugin-Pipelines ausrichten.
+
+## Migrationsleitfaden
+
+Um Plugins über verschiedene Umgebungen hinweg gemeinsam nutzen zu können, muss der Plugin-Status anhand der aktuellen Umgebung verschlüsselt werden. Ein Plugin der folgenden Form zählt die Anzahl der transformierten Module über alle Umgebungen hinweg.
+
+```js
+function CountTransformedModulesPlugin() {
+  let transformedModules
+  return {
+    name: 'count-transformed-modules',
+    buildStart() {
+      transformedModules = 0
+    },
+    transform(id) {
+      transformedModules++
+    },
+    buildEnd() {
+      console.log(transformedModules)
+    },
+  }
+}
+```
+
+Wenn wir stattdessen die Anzahl der transformierten Module für jede Umgebung zählen möchten, müssen wir eine Zuordnung speichern:
+
+```js
+function PerEnvironmentCountTransformedModulesPlugin() {
+  const state = new Map<Environment, { count: number }>()
+  return {
+    name: 'count-transformed-modules',
+    perEnvironmentStartEndDuringDev: true,
+    buildStart() {
+      state.set(this.environment, { count: 0 })
+    }
+    transform(id) {
+      state.get(this.environment).count++
+    },
+    buildEnd() {
+      console.log(this.environment.name, state.get(this.environment).count)
+    }
+  }
+}
+```
+
+Zur Vereinfachung dieses Musters exportiert Vite einen `perEnvironmentState`-Helfer:
+
+```js
+function PerEnvironmentCountTransformedModulesPlugin() {
+  const state = perEnvironmentState<{ count: number }>(() => ({ count: 0 }))
+  return {
+    name: 'count-transformed-modules',
+    perEnvironmentStartEndDuringDev: true,
+    buildStart() {
+      state(this).count = 0
+    }
+    transform(id) {
+      state(this).count++
+    },
+    buildEnd() {
+      console.log(this.environment.name, state(this).count)
+    }
+  }
+}
+```

--- a/docs/changes/ssr-using-modulerunner.md
+++ b/docs/changes/ssr-using-modulerunner.md
@@ -1,0 +1,23 @@
+# SSR verwendet die `ModuleRunner` API
+
+::: tip Feedback
+Geben Sie uns Rückmeldungen in der ["Environment API Feedback"-Diskussion](https://github.com/vitejs/vite/discussions/16358)
+:::
+
+`server.ssrLoadModule` wurde durch die Importierung eines [Module Runners](/guide/api-environment#modulerunner) ersetzt.
+
+Betroffener Bereich: `Vite Plugin-Authoren`
+
+::: warning Zukünftige Veraltungen
+`ModuleRunner` wurde eingeführt in `v6.0`. Die Veraltung von `server.ssrLoadModule` ist für eine zukünftige Hauptversion geplant. Um eine mögliche Nutzung zu identifizieren, können Sie `future.removeSsrLoadModule` in Ihrer Vite-Konfiguration auf `"warn"` setzen.
+:::
+
+## Motivation
+
+`server.ssrLoadModule(url)` erlaubt nur die Importierung von Modulen in der `ssr`-Umgebung und kann nur die Module ausführen, die sich im Gleichen Prozess wie der Vite-Entwicklungsserver befinden. Für Anwendungen mit benutzerdefinierten Umgebungen, wird jede mit einem `ModulRunner` versehen, der in einem seperaten Thread oder Prozess laufen darf. Module können nun mit Hilfe von `moduleRunner.import(url)` importiert werden.
+
+## Migration Guide
+
+Schauen Sie sich den [Environment API für Frameworks Leitfaden](../guide/api-environment-frameworks.md) an.
+
+`server.ssrFixStacktrace` und `server.ssrRewriteStacktrace` müssen nicht aufgerufen werden, wenn die Module Runner APIs verwendet werden. Die Stapelverfolgungen werden aktualisiert, außer `sourcemapInterceptor` wird auf `false` gesetzt.

--- a/docs/changes/this-environment-in-hooks.md
+++ b/docs/changes/this-environment-in-hooks.md
@@ -1,0 +1,43 @@
+# `this.environment` in Hooks
+
+::: tip Feedback
+Geben Sie uns Rückmeldungen in der ["Environment API Feedback"-Diskussion](https://github.com/vitejs/vite/discussions/16358)
+:::
+
+Vor Vite 6 standen nur die Umgebungen `client` und `ssr` zur Verfügung. Ein einzelnes `options.ssr` Plugin-Hook-Argument in `resolveId`, `load` und `transform` ermöglichte Plugin-Authoren in der Verarbeitung von Modulen in Plugin-Hooks zwischen den beiden Umgebungen zu unterscheiden. In Vite 6, eine Vite-Applikation kann, je nach Bedarf, eine beliebige Anzahl der genannten umgebungen definieren. Wir führen `this.environment` im Plugin-Kontext ein, um in den Hooks mit der Umgebung des jeweiligen Moduls interagieren zu können.
+
+Betroffener Bereich: `Vite Plugin-Authoren`
+
+::: warning Zukünftige Veraltungen
+`this.environment` wurde in `v6.0` eingeführt. Die Veraltung von `options.ssr` ist für eine zukünftige Hauptversion geplant. An diesem Pukt werden wir eine Migration der betroffenen Plugins zur neuen API empfehlen. Um eine mögliche Nutzung zu identifizieren, können Sie `future.removePluginHookSsrArgument` in Ihrer Vite-Konfiguration auf `"warn"` setzen.
+:::
+
+## Motivation
+
+`this.environment` erlaubt der Plugin-Hook-Implementation nicht nur den den aktuellen Umgebungsnamen zu kennen, es gestattet auch Zugriff auf die Konfigurationsoptionen, Informationen zum Modulgraph und Pipeline-Transformationen (`environment.config`, `environment.moduleGraph`, `environment.transformRequest()`). Die Verfügbarkeit der Umgebungsinstanz im Kontext ermöglicht es Plugin-Authoren, die Abhängigkeit vom gesamten Server zu vermeiden (typischerweise wird diese zum Start durch die `configureServer`-Hook zwischengespeichert).
+
+## Migrationsleitfaden
+
+Für eine schnelle Migration von existierenden Plugins können Sie das `options.ssr`-Argument mit `this.environment.config.consumer === 'server'` in den `resolveId`-, `load`- und `transform`-Hooks ersetzen.
+
+```ts
+import { Plugin } from 'vite'
+
+export function myPlugin(): Plugin {
+  return {
+    name: 'my-plugin',
+    resolveId(id, importer, options) {
+      const isSSR = options.ssr // [!code --]
+      const isSSR = this.environment.config.consumer === 'server' // [!code ++]
+
+      if (isSSR) {
+        // SSR specific logic
+      } else {
+        // Client specific logic
+      }
+    },
+  }
+}
+```
+
+Für eine robuste und langfristige Implementation sollte die Plugin-Hook [mehrere Umgebungen](/guide/api-environment-plugins.html#accessing-the-current-environment-in-hooks) behandeln, welche auf fein abgestimmte Umgebungsoptionen anstelle des reinen Umgebungsnamen beruhen sollte.


### PR DESCRIPTION
Ich habe das Verzeichnis aus dem originalen Repository kopiert, hier eingefügt und übersetzt. Zusätzlich habe ich noch die Links in der Seitenleiste im Bereich "Leitfaden" ergänzt,  damit der Bereich auch erreichbar ist. 

@rojadesign Schau gerne mal drüber, ob es für's Erste so passt. Ich habe schon gesehen, dass dort in Zukunft nochmal Anpassungen vorgenommen werden müssen.